### PR TITLE
Make popup widget scrollable

### DIFF
--- a/src/widgets/statistics.tsx
+++ b/src/widgets/statistics.tsx
@@ -18,7 +18,7 @@ export const Statistics = () => {
     chartColor = chartColorSettings;
   }
 
-  return <div class="statisticsBody">
+  return <div style={{ maxHeight: "calc(90vh)" }} class="statisticsBody overflow-y-auto">
     <div><b>Retention rate: </b> {(retentionRate(getNumberRepetitionsGroupedByScore(allCards)))}</div>
     <div class="vSpacing-1rem"/>
     {chart_column(


### PR DESCRIPTION
- Sets the max height of the statistics div container to 90% of the viewport
- Adds overflow-y-auto class to make it scrollable if it overflows

Please check this works for you when you recompile and run the plugin, I just checked quickly in chrome dev tools :)